### PR TITLE
Ignore empty queries in QueryLoaderFile

### DIFF
--- a/lib/QueryLoaderFile.ts
+++ b/lib/QueryLoaderFile.ts
@@ -18,7 +18,9 @@ export class QueryLoaderFile implements IQueryLoader {
       const extension = extname(file.name);
       if (file.isFile() && this.extensions.has(extension)) {
         const fileContents = await readFile(join(file.path, file.name), { encoding: 'utf-8' });
-        const queries = fileContents.split(querySeparator);
+        const queries = fileContents.split(querySeparator)
+          .map(query => query.trim())
+          .filter(query => query.length > 0);
         querySets[file.name.replace(extension, '')] = queries;
       }
     }

--- a/test/QueryLoaderFile-test.ts
+++ b/test/QueryLoaderFile-test.ts
@@ -8,7 +8,7 @@ const queryFilesPath = '/tmp/queries';
 
 const queryFiles: Record<string, string> = {
   'a.rq': 'A',
-  'b.sparql': 'B1\n\nB2',
+  'b.sparql': 'B1\n\nB2\n\n\n\n',
   'c.txt': 'C',
   'd.json': 'D',
 };


### PR DESCRIPTION
This is a fix for the file query loader, so that it ignores queries that do not actually exist. For example, if a file would have two newlines at the end of it (as the WatDiv queries do), the resulting final empty query from the split should not be considered.

I also added it to the unit test.