### PR TITLE
Remove the use of Dirent.path as deprecated

### DIFF
--- a/lib/QueryLoaderFile.ts
+++ b/lib/QueryLoaderFile.ts
@@ -14,14 +14,16 @@ export class QueryLoaderFile implements IQueryLoader {
   public async loadQueries(): Promise<Record<string, string[]>> {
     const querySets: Record<string, string[]> = {};
     const querySeparator = '\n\n';
-    for (const file of await readdir(this.path, { encoding: 'utf-8', withFileTypes: true })) {
-      const extension = extname(file.name);
-      if (file.isFile() && this.extensions.has(extension)) {
-        const fileContents = await readFile(join(file.path, file.name), { encoding: 'utf-8' });
-        const queries = fileContents.split(querySeparator)
-          .map(query => query.trim())
-          .filter(query => query.length > 0);
-        querySets[file.name.replace(extension, '')] = queries;
+    for (const dirent of await readdir(this.path, { encoding: 'utf-8', withFileTypes: true })) {
+      if (dirent.isFile()) {
+        const extension = extname(dirent.name);
+        if (this.extensions.has(extension)) {
+          const fileContents = await readFile(join(this.path, dirent.name), { encoding: 'utf-8' });
+          const queries = fileContents.split(querySeparator)
+            .map(query => query.trim())
+            .filter(query => query.length > 0);
+          querySets[dirent.name.replace(extension, '')] = queries;
+        }
       }
     }
     return querySets;

--- a/test/QueryLoaderFile-test.ts
+++ b/test/QueryLoaderFile-test.ts
@@ -18,7 +18,6 @@ jest.mock<typeof fsPromises>('node:fs/promises', () => <typeof fsPromises> <unkn
     if (path === queryFilesPath) {
       return Object.keys(queryFiles).map(file => (<Dirent> {
         name: file,
-        path: queryFilesPath,
         isFile: () => true,
       }));
     }


### PR DESCRIPTION
This should fix some weird errors with certain Node versions, where the `path` on a `Dirent` was pointing at either the parent path or the path of the entry itself, in a really inconsistent way. It turns out that the `path` entry has been [deprecated](https://nodejs.org/docs/latest-v18.x/api/fs.html#direntpath), but it is still offered in the autocompletion for some reason, whereas the replacement is not.

The simple solution is to remove its use, because the query loader can use the supplied path as the base for joining.

This should help get comunica/comunica#1340 pass the CI on Node 18.