### PR TITLE
Sequence-based Benchmark runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ async function executeQueries(pathToQueries, pathToOutputCsv) {
 
   const results = await runner.run();
 
-  await resultSerializer.serialize(pathToOutputCsv, results.aggregateResults);
+  await resultSerializer.serialize(pathToOutputCsv, results);
 }
 ```
 
@@ -128,6 +128,10 @@ To enable sequence metadata from the CLI, add `--metadata`. Raw JSON output is
 only written when `--outputRaw` is provided, or automatically to
 `./output-raw.json` when `--metadata` is enabled. Cache refresh requests are
 disabled by default and can be enabled with `--refreshAfterQuerySet`.
+
+`run()` remains backward compatible with earlier versions that returned the
+aggregated results array directly. The returned array now also exposes
+`aggregateResults` and `rawResults` properties for callers that need both views.
 
 ## Docker
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ async function executeQueries(pathToQueries, pathToOutputCsv) {
 
   const results = await runner.run();
 
-  await resultSerializer.serialize(pathToOutputCsv, results);
+  await resultSerializer.serialize(pathToOutputCsv, results.aggregateResults);
 }
 ```
 
@@ -128,10 +128,6 @@ To enable sequence metadata from the CLI, add `--metadata`. Raw JSON output is
 only written when `--outputRaw` is provided, or automatically to
 `./output-raw.json` when `--metadata` is enabled. Cache refresh requests are
 disabled by default and can be enabled with `--refreshAfterQuerySet`.
-
-`run()` remains backward compatible with earlier versions that returned the
-aggregated results array directly. The returned array now also exposes
-`aggregateResults` and `rawResults` properties for callers that need both views.
 
 ## Docker
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,12 @@ Options:
   --replication  Number of replication runs                [number] [default: 5]
   --warmup       Number of warmup runs                     [number] [default: 1]
   --output       Destination for the output CSV file
-                                              [string] [default: "./output.csv"]
+                                               [string] [default: "./output.csv"]
+  --outputRaw    Destination for the raw JSON output file                 [string]
+  --metadata     Load query metadata files (*.metadata.json) and enable
+                 sequence aggregation                   [boolean] [default: false]
+  --refreshAfterQuerySet  Send a cache refresh request after each query set
+                 execution                              [boolean] [default: false]
   --timeout      Timeout value in seconds to use for individual queries [number]
   ----help
 ```
@@ -84,6 +89,8 @@ result aggregators and result serializers to accommodate special use cases.
 By default, when no specific result aggregator is provided,
 the runner uses `ResultAggregatorComunica` that handles basic aggregation,
 as well as the `httpRequests` metadata field from a Comunica SPARQL endpoint, if such metadata is provided.
+Metadata-based sequence aggregation is optional and can be enabled by passing
+query metadata to the runner together with `ResultAggregatorComunicaQuerySequence`.
 
 ```javascript
 import {
@@ -113,9 +120,14 @@ async function executeQueries(pathToQueries, pathToOutputCsv) {
 
   const results = await runner.run();
 
-  await resultSerializer.serialize(path, results);
+  await resultSerializer.serialize(pathToOutputCsv, results.aggregateResults);
 }
 ```
+
+To enable sequence metadata from the CLI, add `--metadata`. Raw JSON output is
+only written when `--outputRaw` is provided, or automatically to
+`./output-raw.json` when `--metadata` is enabled. Cache refresh requests are
+disabled by default and can be enabled with `--refreshAfterQuerySet`.
 
 ## Docker
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Options:
   --outputRaw    Destination for the raw JSON output file                 [string]
   --metadata     Load query metadata files (*.metadata.json) and enable
                  sequence aggregation                   [boolean] [default: false]
-  --refreshAfterQuerySet  Send a cache refresh request after each query set
+  --invalidateCacheAfterQuerySet  Send a cache invalidation request after each query set
                  execution                              [boolean] [default: false]
   --timeout      Timeout value in seconds to use for individual queries [number]
   ----help
@@ -126,8 +126,8 @@ async function executeQueries(pathToQueries, pathToOutputCsv) {
 
 To enable sequence metadata from the CLI, add `--metadata`. Raw JSON output is
 only written when `--outputRaw` is provided, or automatically to
-`./output-raw.json` when `--metadata` is enabled. Cache refresh requests are
-disabled by default and can be enabled with `--refreshAfterQuerySet`.
+`./output-raw.json` when `--metadata` is enabled. Cache invalidation requests are
+disabled by default and can be enabled with `--invalidateCacheAfterQuerySet`.
 
 ## Docker
 

--- a/bin/sparql-benchmark-runner.ts
+++ b/bin/sparql-benchmark-runner.ts
@@ -111,7 +111,7 @@ async function main(): Promise<void> {
   });
 
   const results: IRunResult = await runner.run();
-  await serializeResults(args.output, results);
+  await serializeResults(args.output, results.aggregateResults);
   const outputRaw = args.outputRaw ?? (args.metadata ? resolve('./output-raw.json') : undefined);
   if (results.rawResults && outputRaw) {
     await serializeRawResults(outputRaw, results.rawResults);

--- a/bin/sparql-benchmark-runner.ts
+++ b/bin/sparql-benchmark-runner.ts
@@ -1,7 +1,7 @@
 import { resolve } from 'node:path';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
-import type { IQueryLoader } from '../lib/QueryLoader';
+import type { IQueryLoader, IQuerySetMetadata } from '../lib/QueryLoader';
 import { QueryLoaderFile } from '../lib/QueryLoaderFile';
 import type { IAggregateResult, IResult, IRunResult } from '../lib/Result';
 import { ResultAggregatorComunicaQuerySequence } from '../lib/ResultAggregatorComunicaQuerySequence';
@@ -18,9 +18,9 @@ async function loadQueries(path: string): Promise<Record<string, string[]>> {
   return await loader.loadQueries();
 }
 
-async function loadQueryMetadata(path: string): Promise<Record<string, Record<string, any>>> {
+async function loadQueryMetadata(path: string): Promise<Record<string, IQuerySetMetadata>> {
   const loader: IQueryLoader = new QueryLoaderFile({ path });
-  logger(`Loading queries from ${path}`);
+  logger(`Loading query metadata from ${path}`);
   return await loader.loadQueriesMetadata();
 }
 
@@ -71,9 +71,18 @@ async function main(): Promise<void> {
       },
       outputRaw: {
         type: 'string',
-        default: './output-raw.json',
-        description: 'Destination for the output CSV file',
+        description: 'Destination for the raw JSON output file',
         coerce: (arg: string) => resolve(arg),
+      },
+      metadata: {
+        type: 'boolean',
+        default: false,
+        description: 'Load query metadata files (*.metadata.json) and enable sequence aggregation',
+      },
+      refreshAfterQuerySet: {
+        type: 'boolean',
+        default: false,
+        description: 'Send a cache refresh request after each query set execution',
       },
 
       timeout: {
@@ -86,10 +95,10 @@ async function main(): Promise<void> {
     .help()
     .parse();
   const querySets = await loadQueries(args.queries);
-  const querySetsMetadata = await loadQueryMetadata(args.queries);
+  const querySetsMetadata = args.metadata ? await loadQueryMetadata(args.queries) : undefined;
 
   const runner = new SparqlBenchmarkRunner({
-    resultAggregator: new ResultAggregatorComunicaQuerySequence(),
+    resultAggregator: args.metadata ? new ResultAggregatorComunicaQuerySequence() : undefined,
     endpoint: args.endpoint,
     querySets,
     querySetsMetadata,
@@ -98,12 +107,14 @@ async function main(): Promise<void> {
     timeout: args.timeout,
     availabilityCheckTimeout: 1_000,
     logger,
+    resetCacheBetweenSetExecutions: args.refreshAfterQuerySet,
   });
 
   const results: IRunResult = await runner.run();
   await serializeResults(args.output, results.aggregateResults);
-  if (results.rawResults) {
-    await serializeRawResults(args.outputRaw, results.rawResults);
+  const outputRaw = args.outputRaw ?? (args.metadata ? resolve('./output-raw.json') : undefined);
+  if (results.rawResults && outputRaw) {
+    await serializeRawResults(outputRaw, results.rawResults);
   }
 }
 

--- a/bin/sparql-benchmark-runner.ts
+++ b/bin/sparql-benchmark-runner.ts
@@ -110,7 +110,7 @@ async function main(): Promise<void> {
     invalidateCacheBetweenSetExecutions: args.invalidateCacheAfterQuerySet,
   });
 
-  const results: IRunResult = await runner.run();
+  const results: IRunResult = await runner.runWithRawResults();
   await serializeResults(args.output, results.aggregateResults);
   const outputRaw = args.outputRaw ?? (args.metadata ? resolve('./output-raw.json') : undefined);
   if (results.rawResults && outputRaw) {

--- a/bin/sparql-benchmark-runner.ts
+++ b/bin/sparql-benchmark-runner.ts
@@ -79,10 +79,10 @@ async function main(): Promise<void> {
         default: false,
         description: 'Load query metadata files (*.metadata.json) and enable sequence aggregation',
       },
-      refreshAfterQuerySet: {
+      invalidateCacheAfterQuerySet: {
         type: 'boolean',
         default: false,
-        description: 'Send a cache refresh request after each query set execution',
+        description: 'Send a cache invalidation request after each query set execution',
       },
 
       timeout: {
@@ -107,7 +107,7 @@ async function main(): Promise<void> {
     timeout: args.timeout,
     availabilityCheckTimeout: 1_000,
     logger,
-    resetCacheBetweenSetExecutions: args.refreshAfterQuerySet,
+    invalidateCacheBetweenSetExecutions: args.invalidateCacheAfterQuerySet,
   });
 
   const results: IRunResult = await runner.run();

--- a/bin/sparql-benchmark-runner.ts
+++ b/bin/sparql-benchmark-runner.ts
@@ -111,7 +111,7 @@ async function main(): Promise<void> {
   });
 
   const results: IRunResult = await runner.run();
-  await serializeResults(args.output, results.aggregateResults);
+  await serializeResults(args.output, results);
   const outputRaw = args.outputRaw ?? (args.metadata ? resolve('./output-raw.json') : undefined);
   if (results.rawResults && outputRaw) {
     await serializeRawResults(outputRaw, results.rawResults);

--- a/lib/QueryLoader.ts
+++ b/lib/QueryLoader.ts
@@ -1,3 +1,4 @@
 export interface IQueryLoader {
   loadQueries: () => Promise<Record<string, string[]>>;
+  loadQueriesMetadata: () => Promise<Record<string, Record<string, any>>>;
 }

--- a/lib/QueryLoader.ts
+++ b/lib/QueryLoader.ts
@@ -1,4 +1,6 @@
 export interface IQueryLoader {
   loadQueries: () => Promise<Record<string, string[]>>;
-  loadQueriesMetadata: () => Promise<Record<string, Record<string, any>>>;
+  loadQueriesMetadata: () => Promise<Record<string, IQuerySetMetadata>>;
 }
+
+export type IQuerySetMetadata = Record<string, any>[];

--- a/lib/QueryLoaderFile.ts
+++ b/lib/QueryLoaderFile.ts
@@ -5,16 +5,35 @@ import type { IQueryLoader } from './QueryLoader';
 export class QueryLoaderFile implements IQueryLoader {
   protected readonly path: string;
   protected readonly extensions: Set<string>;
+  protected readonly extensionsMetadata: Set<string>;
+  protected readonly indicatorsMetadata: Set<string>;
 
   public constructor(options: IQueryLoaderFileOptions) {
     this.path = resolve(options.path);
     this.extensions = new Set<string>(options.extensions ?? [ '.txt', '.sparql', '.rq' ]);
+    this.extensionsMetadata = new Set<string>(
+      options.extensionsMetadata ?? [ '.json' ],
+    );
+    this.indicatorsMetadata = new Set<string>(
+      options.indicatorsMetadata ?? [ '.metadata' ],
+    );
   }
 
   public async loadQueries(): Promise<Record<string, string[]>> {
     const querySets: Record<string, string[]> = {};
     await QueryLoaderFile.loadQueriesStatic(querySets, this.path, this.extensions);
     return querySets;
+  }
+
+  public async loadQueriesMetadata(): Promise<Record<string, Record<string, any>>> {
+    const queryMetadata: Record<string, Record<string, any>> = {};
+    await QueryLoaderFile.loadQueriesMetadataStatic(
+      queryMetadata,
+      this.path,
+      this.extensionsMetadata,
+      this.indicatorsMetadata,
+    );
+    return queryMetadata;
   }
 
   protected static async loadQueriesStatic(
@@ -39,6 +58,102 @@ export class QueryLoaderFile implements IQueryLoader {
       }
     }
   }
+
+  /**
+   * Load metadata describing the queries in a query set. Each metadata file
+   * should be associated with a query file (with the same name excluding extensions)
+   *
+   * The metadata files are expected to have the following structure:
+   * - An arbitrary number of top-level fields with single values, representing
+   *   global metadata for the whole query set (e.g., template, provenance,
+   *   bottleneck type).
+   * - Exactly one top-level field whose value is an array. Each element of
+   *   this array describes the metadata of an individual query in the set.
+   *
+   * During loading:
+   * - All global (single-value) fields are repeated and attached to each
+   *   individual query metadata object.
+   * - Each element of the array field becomes one entry in the final list,
+   *   preserving the original order of the array.
+   *
+   * Example input:
+   * {
+   *   "template": "interactive-discover-3",
+   *   "provenance": "benchmarkX",
+   *   "sequenceElements": [
+   *     { "session": { "task": "Messages Person" } },
+   *     { "session": { "task": "Another Task" } }
+   *   ]
+   * }
+   *
+   * Example output:
+   * [
+   *   {
+   *     "template": "interactive-discover-3",
+   *     "provenance": "benchmarkX",
+   *     "sequenceElement": { "session": { "task": "Messages Person" } }
+   *   },
+   *   {
+   *     "template": "interactive-discover-3",
+   *     "provenance": "benchmarkX",
+   *     "sequenceElement": { "session": { "task": "Another Task" } }
+   *   }
+   * ]
+   */
+  protected static async loadQueriesMetadataStatic(
+    queryMetadata: Record<string, Record<string, any>>,
+    path: string,
+    extensions: Set<string>,
+    indicators: Set<string>,
+    prefix = '',
+  ): Promise<void> {
+    for (const dirent of await readdir(path, { encoding: 'utf-8', withFileTypes: true })) {
+      if (dirent.isFile()) {
+        const extension = extname(dirent.name);
+        if (extensions.has(extension)) {
+          const filePath = join(path, dirent.name);
+          const raw = await readFile(filePath, 'utf-8');
+          const parsed = <Record<string, any>> JSON.parse(raw);
+
+          // Assume there's exactly one array field (like "sequenceElements")
+          let arrayKey: string | undefined;
+          let arrayValue: any[] | undefined;
+          for (const key in parsed) {
+            if (Array.isArray(parsed[key])) {
+              arrayKey = key;
+              arrayValue = <any[]> parsed[key];
+            }
+          }
+          if (!arrayValue || !arrayKey) {
+            throw new Error('queries metadata has no array entry');
+          }
+
+          const baseFields = Object.fromEntries(
+            Object.entries(parsed).filter(([ , v ]) => !Array.isArray(v)),
+          );
+
+          for (const element of arrayValue) {
+            const obj = { ...baseFields, [arrayKey.slice(0, -1)]: <Record<string, any>> element };
+            const cleanedDirent = this.removeMatches(dirent.name.replace(extension, ''), indicators);
+            // Store as array of objects per file
+            (queryMetadata[prefix + cleanedDirent] ??= []).push(obj);
+          }
+        }
+      } else if (dirent.isDirectory()) {
+        await QueryLoaderFile.loadQueriesMetadataStatic(queryMetadata, join(path, dirent.name), extensions, indicators, `${prefix}${dirent.name}/`);
+      }
+    }
+  }
+
+  protected static removeMatches(filename: string, metadataIndicators: Set<string>): string {
+    let stripped = filename;
+    for (const indicator of metadataIndicators) {
+      if (stripped.includes(indicator)) {
+        stripped = stripped.replace(indicator, '');
+      }
+    }
+    return stripped;
+  }
 }
 
 export interface IQueryLoaderFileOptions {
@@ -50,4 +165,15 @@ export interface IQueryLoaderFileOptions {
    * File extensions to detect as SPARQL queries.
    */
   extensions?: string[];
+  /**
+   * File extensions to detect as SPARQL queries metadata
+   */
+  extensionsMetadata?: string[];
+  /**
+   * File name additions to indicate that this represents metadata of
+   * the file with the indicator removed. For example:
+   * testQueriesOne.sparql has metadata file testQueriesOne.metadata.json.
+   * Here .metadata is the indicator and .json is the extension
+   */
+  indicatorsMetadata?: string[];
 }

--- a/lib/QueryLoaderFile.ts
+++ b/lib/QueryLoaderFile.ts
@@ -1,6 +1,6 @@
 import { readdir, readFile } from 'node:fs/promises';
 import { join, extname, resolve } from 'node:path';
-import type { IQueryLoader } from './QueryLoader';
+import type { IQueryLoader, IQuerySetMetadata } from './QueryLoader';
 
 export class QueryLoaderFile implements IQueryLoader {
   protected readonly path: string;
@@ -25,8 +25,8 @@ export class QueryLoaderFile implements IQueryLoader {
     return querySets;
   }
 
-  public async loadQueriesMetadata(): Promise<Record<string, Record<string, any>>> {
-    const queryMetadata: Record<string, Record<string, any>> = {};
+  public async loadQueriesMetadata(): Promise<Record<string, IQuerySetMetadata>> {
+    const queryMetadata: Record<string, IQuerySetMetadata> = {};
     await QueryLoaderFile.loadQueriesMetadataStatic(
       queryMetadata,
       this.path,
@@ -101,7 +101,7 @@ export class QueryLoaderFile implements IQueryLoader {
    * ]
    */
   protected static async loadQueriesMetadataStatic(
-    queryMetadata: Record<string, Record<string, any>>,
+    queryMetadata: Record<string, IQuerySetMetadata>,
     path: string,
     extensions: Set<string>,
     indicators: Set<string>,
@@ -111,6 +111,10 @@ export class QueryLoaderFile implements IQueryLoader {
       if (dirent.isFile()) {
         const extension = extname(dirent.name);
         if (extensions.has(extension)) {
+          const fileNameWithoutExtension = dirent.name.replace(extension, '');
+          if (!this.hasMetadataIndicator(fileNameWithoutExtension, indicators)) {
+            continue;
+          }
           const filePath = join(path, dirent.name);
           const raw = await readFile(filePath, 'utf-8');
           const parsed = <Record<string, any>> JSON.parse(raw);
@@ -134,7 +138,7 @@ export class QueryLoaderFile implements IQueryLoader {
 
           for (const element of arrayValue) {
             const obj = { ...baseFields, [arrayKey.slice(0, -1)]: <Record<string, any>> element };
-            const cleanedDirent = this.removeMatches(dirent.name.replace(extension, ''), indicators);
+            const cleanedDirent = this.removeMatches(fileNameWithoutExtension, indicators);
             // Store as array of objects per file
             (queryMetadata[prefix + cleanedDirent] ??= []).push(obj);
           }
@@ -153,6 +157,15 @@ export class QueryLoaderFile implements IQueryLoader {
       }
     }
     return stripped;
+  }
+
+  protected static hasMetadataIndicator(filename: string, metadataIndicators: Set<string>): boolean {
+    for (const indicator of metadataIndicators) {
+      if (filename.includes(indicator)) {
+        return true;
+      }
+    }
+    return false;
   }
 }
 

--- a/lib/Result.ts
+++ b/lib/Result.ts
@@ -59,3 +59,11 @@ export interface IAggregateResult extends IResult {
   // Raw timestamps for all repetitions, preserving individual result arrival times.
   timestampsAll: number[][];
 }
+
+export interface IRunResult {
+  // Aggregated result of the run
+  aggregateResults: IAggregateResult[];
+
+  // Optional raw results of the run
+  rawResults?: IResult[];
+}

--- a/lib/Result.ts
+++ b/lib/Result.ts
@@ -60,12 +60,10 @@ export interface IAggregateResult extends IResult {
   timestampsAll: number[][];
 }
 
-export interface IRunResultObject {
+export interface IRunResult {
   // Aggregated result of the run
   aggregateResults: IAggregateResult[];
 
   // Optional raw results of the run
   rawResults?: IResult[];
 }
-
-export type IRunResult = IAggregateResult[] & IRunResultObject;

--- a/lib/Result.ts
+++ b/lib/Result.ts
@@ -60,10 +60,12 @@ export interface IAggregateResult extends IResult {
   timestampsAll: number[][];
 }
 
-export interface IRunResult {
+export interface IRunResultObject {
   // Aggregated result of the run
   aggregateResults: IAggregateResult[];
 
   // Optional raw results of the run
   rawResults?: IResult[];
 }
+
+export type IRunResult = IAggregateResult[] & IRunResultObject;

--- a/lib/ResultAggregatorComunicaQuerySequence.ts
+++ b/lib/ResultAggregatorComunicaQuerySequence.ts
@@ -1,0 +1,78 @@
+import type { IResult, IAggregateResult } from './Result';
+import { ResultAggregatorComunica } from './ResultAggregatorComunica';
+
+/**
+ * Query result aggregator that handles Comunica-specific metadata.
+ */
+export class ResultAggregatorComunicaQuerySequence extends ResultAggregatorComunica {
+  /**
+   * Groups query execution results by name and id.
+   * @param results Ungrouped results.
+   * @returns Grouped results.
+   */
+  public override groupResults(results: IResult[]): Record<string, IResult[]> {
+    const templates: Record<string, IResult[]> = {};
+    for (const result of results) {
+      const template = <string> result.template;
+      result.sequence = result.name;
+      result.name = template;
+      if (!(template in templates)) {
+        templates[template] = [];
+      }
+      templates[template].push(result);
+    }
+    return templates;
+  }
+
+  public groupAggregateResults(results: IResult[]): Record<string, IResult[]> {
+    const groups: Record<string, IResult[]> = {};
+    for (const result of results) {
+      const key = `${result.name}`;
+      if (key in groups) {
+        groups[key].push(result);
+      } else {
+        groups[key] = [ result ];
+      }
+    }
+    return groups;
+  }
+
+  public aggregateResults(results: IResult[]): IAggregateResult[] {
+    for (const result of results) {
+      result.template = <string> result.sequenceElement.template;
+    }
+
+    const groupedResults = this.groupResults(results);
+    const aggregateResults = this.aggregateGroupedResults(groupedResults);
+    const groupedAggregates = this.groupAggregateResults(aggregateResults);
+
+    for (const [ key, resultGroup ] of Object.entries(groupedResults)) {
+      let requestsSum = 0;
+      let requestsMax = 0;
+      let requestsMin = 0;
+      let successfulExecutions = 0;
+      for (const result of resultGroup.filter(res => !res.error && typeof res.httpRequests === 'number')) {
+        const resultHttpRequests = <number>result.httpRequests;
+        requestsSum = successfulExecutions > 0 ? requestsSum + resultHttpRequests : resultHttpRequests;
+        requestsMax = successfulExecutions > 0 ? Math.max(requestsMax, resultHttpRequests) : resultHttpRequests;
+        requestsMin = successfulExecutions > 0 ? Math.min(requestsMin, resultHttpRequests) : resultHttpRequests;
+        successfulExecutions++;
+      }
+      if (successfulExecutions > 0) {
+        groupedAggregates[key][0].httpRequests = requestsSum / successfulExecutions;
+        groupedAggregates[key][0].httpRequestsMax = requestsMax;
+        groupedAggregates[key][0].httpRequestsMin = requestsMin;
+        groupedAggregates[key][0].httpRequestsStd = 0;
+
+        for (const { httpRequests, error } of resultGroup) {
+          if (!error) {
+            groupedAggregates[key][0].httpRequestsStd += (httpRequests - groupedAggregates[key][0].httpRequests) ** 2;
+          }
+        }
+        groupedAggregates[key][0].httpRequestsStd =
+         Math.sqrt(groupedAggregates[key][0].httpRequestsStd / successfulExecutions);
+      }
+    }
+    return aggregateResults;
+  }
+}

--- a/lib/ResultAggregatorComunicaQuerySequence.ts
+++ b/lib/ResultAggregatorComunicaQuerySequence.ts
@@ -13,13 +13,16 @@ export class ResultAggregatorComunicaQuerySequence extends ResultAggregatorComun
   public override groupResults(results: IResult[]): Record<string, IResult[]> {
     const templates: Record<string, IResult[]> = {};
     for (const result of results) {
-      const template = <string> result.template;
-      result.sequence = result.name;
-      result.name = template;
-      if (!(template in templates)) {
-        templates[template] = [];
+      const template = typeof result.template === 'string' ? result.template : undefined;
+      if (template) {
+        result.sequence = result.name;
+        result.name = template;
       }
-      templates[template].push(result);
+      const key = template ?? result.name;
+      if (!(key in templates)) {
+        templates[key] = [];
+      }
+      templates[key].push(result);
     }
     return templates;
   }
@@ -39,7 +42,10 @@ export class ResultAggregatorComunicaQuerySequence extends ResultAggregatorComun
 
   public aggregateResults(results: IResult[]): IAggregateResult[] {
     for (const result of results) {
-      result.template = <string> result.sequenceElement.template;
+      const sequenceElementTemplate: unknown = result.sequenceElement?.template;
+      if (typeof result.template !== 'string' && typeof sequenceElementTemplate === 'string') {
+        result.template = sequenceElementTemplate;
+      }
     }
 
     const groupedResults = this.groupResults(results);

--- a/lib/ResultAggregatorComunicaQuerySequence.ts
+++ b/lib/ResultAggregatorComunicaQuerySequence.ts
@@ -18,7 +18,7 @@ export class ResultAggregatorComunicaQuerySequence extends ResultAggregatorComun
         result.sequence = result.name;
         result.name = template;
       }
-      const key = template ?? result.name;
+      const key: string = template ?? result.name;
       if (!(key in templates)) {
         templates[key] = [];
       }

--- a/lib/ResultSerializerRaw.ts
+++ b/lib/ResultSerializerRaw.ts
@@ -19,7 +19,11 @@ export class ResultSerializerRaw extends ResultSerializer {
    * @param results The benchmark results to serialize.
    */
   public async serialize<T extends IResult>(path: string, results: T[]): Promise<void> {
-    await writeFile(path, JSON.stringify(results, null, 2), 'utf-8');
+    const resultsErrorMessages = results.map(result => ({
+      ...result,
+      error: result.error?.message ?? result.error,
+    }));
+    await writeFile(path, JSON.stringify(resultsErrorMessages, null, 2), 'utf-8');
   }
 }
 

--- a/lib/ResultSerializerRaw.ts
+++ b/lib/ResultSerializerRaw.ts
@@ -1,0 +1,29 @@
+import { writeFile } from 'node:fs/promises';
+import type { IResult } from './Result';
+import { ResultSerializer } from './ResultSerializer';
+import type { IResultSerializerOptions } from './ResultSerializer';
+
+export class ResultSerializerRaw extends ResultSerializer {
+  protected readonly columnSeparator: string;
+  protected readonly arraySeparator: string;
+
+  public constructor(options?: IResultSerializerCsvOptions) {
+    super(options);
+    this.columnSeparator = options?.columnSeparator ?? ';';
+    this.arraySeparator = options?.arraySeparator ?? ' ';
+  }
+
+  /**
+   * Write raw results to JSON file.
+   * @param path The destination file path.
+   * @param results The benchmark results to serialize.
+   */
+  public async serialize<T extends IResult>(path: string, results: T[]): Promise<void> {
+    await writeFile(path, JSON.stringify(results, null, 2), 'utf-8');
+  }
+}
+
+export interface IResultSerializerCsvOptions extends IResultSerializerOptions {
+  columnSeparator: string;
+  arraySeparator: string;
+}

--- a/lib/ResultSerializerRaw.ts
+++ b/lib/ResultSerializerRaw.ts
@@ -7,7 +7,7 @@ export class ResultSerializerRaw extends ResultSerializer {
   protected readonly columnSeparator: string;
   protected readonly arraySeparator: string;
 
-  public constructor(options?: IResultSerializerCsvOptions) {
+  public constructor(options?: IResultSerializerRawOptions) {
     super(options);
     this.columnSeparator = options?.columnSeparator ?? ';';
     this.arraySeparator = options?.arraySeparator ?? ' ';
@@ -23,7 +23,7 @@ export class ResultSerializerRaw extends ResultSerializer {
   }
 }
 
-export interface IResultSerializerCsvOptions extends IResultSerializerOptions {
+export interface IResultSerializerRawOptions extends IResultSerializerOptions {
   columnSeparator: string;
   arraySeparator: string;
 }

--- a/lib/SparqlBenchmarkRunner.ts
+++ b/lib/SparqlBenchmarkRunner.ts
@@ -111,7 +111,7 @@ export class SparqlBenchmarkRunner {
             await onQuery(queryString);
           }
           let result = await this.executeQuery(name, id.toString(), queryString);
-          if (this.querySetsMetadata) {
+          if (this.querySetsMetadata && Object.keys(this.querySetsMetadata).length > 0) {
             result = { ...result, ...<any[]> this.querySetsMetadata[name][id] };
           }
           if (!warmup) {

--- a/lib/SparqlBenchmarkRunner.ts
+++ b/lib/SparqlBenchmarkRunner.ts
@@ -2,6 +2,7 @@ import { createHash, type Hash } from 'node:crypto';
 import type * as RDF from '@rdfjs/types';
 import { SparqlEndpointFetcher } from 'fetch-sparql-endpoint';
 import { termToString } from 'rdf-string';
+import type { IQuerySetMetadata } from './QueryLoader';
 import type { IResult, IResultMetadata, IRunResult } from './Result';
 import type { IResultAggregator } from './ResultAggregator';
 import { ResultAggregatorComunica } from './ResultAggregatorComunica';
@@ -17,7 +18,7 @@ export class SparqlBenchmarkRunner {
   protected readonly replication: number;
   protected readonly warmup: number;
   protected readonly querySets: Record<string, string[]>;
-  protected readonly querySetsMetadata?: Record<string, Record<string, any>>;
+  protected readonly querySetsMetadata?: Record<string, IQuerySetMetadata>;
   protected readonly bindingsHashAlgorithm: string;
   protected readonly logger?: (message: string) => void;
   protected readonly resultAggregator: IResultAggregator;
@@ -38,7 +39,7 @@ export class SparqlBenchmarkRunner {
     this.requestDelay = options.requestDelay;
     this.bindingsHashAlgorithm = 'md5';
     this.availabilityCheckTimeout = options.availabilityCheckTimeout ?? 10_000;
-    this.sendResetSignalBetweenQuerySets = options.resetCacheBetweenSetExecutions ?? true;
+    this.sendResetSignalBetweenQuerySets = options.resetCacheBetweenSetExecutions ?? false;
     this.endpointFetcher = new SparqlEndpointFetcher({
       additionalUrlParams: options.additionalUrlParams,
       timeout: options.timeout,
@@ -105,20 +106,22 @@ export class SparqlBenchmarkRunner {
       for (let i = 0; i < replication; i++) {
         for (const [ id, queryString ] of queryStrings.entries()) {
           this.log(`Execute: ${(++finishedExecutions).toString().padStart(totalExecutions.length, ' ')} / ${totalExecutions} <${name}#${id}>`);
-          
+
           await this.waitForEndpoint();
-          
+
           if (this.requestDelay) {
             await this.sleep(this.requestDelay);
           }
           if (onQuery) {
             await onQuery(queryString);
           }
-          
+
           let result = await this.executeQuery(name, id.toString(), queryString);
 
-          if (this.querySetsMetadata && Object.keys(this.querySetsMetadata).length > 0) {
-            result = { ...result, ...<any[]> this.querySetsMetadata[name][id] };
+          const querySetMetadata = this.querySetsMetadata?.[name];
+          const queryMetadata = querySetMetadata?.[id];
+          if (queryMetadata) {
+            result = { ...result, ...queryMetadata };
           }
           if (!warmup) {
             results.push(result);
@@ -132,11 +135,11 @@ export class SparqlBenchmarkRunner {
         if (this.sendResetSignalBetweenQuerySets) {
           this.log(`Sending cache refresh signal to trigger worker restart.`);
           try {
+            const refreshHeaders = new Headers();
+            refreshHeaders.set('x-comunica-refresh-cache', 'true');
             await fetch(this.endpoint, {
               method: 'GET',
-              headers: {
-                'x-comunica-refresh-cache': 'true'
-              }
+              headers: refreshHeaders,
             });
           } catch {
             // Suppress error: The server terminates the connection forcefully during shutdown.
@@ -216,12 +219,12 @@ export class SparqlBenchmarkRunner {
     return result;
   }
 
-  public attachMetadataToResults(results: IResult[], metadatas: Record<string, Record<string, any>>):
+  public attachMetadataToResults(results: IResult[], metadatas?: IQuerySetMetadata):
   Record<string, any>[] {
-    return results.map((result, i) => ({
-      ...result,
-      ...metadatas[i],
-    }));
+    return results.map((result, i) => {
+      const metadata = metadatas?.[i];
+      return metadata ? { ...result, ...metadata } : { ...result };
+    });
   }
 
   /**
@@ -311,7 +314,7 @@ export interface ISparqlBenchmarkRunnerArgs {
   /**
    * Mapping of query set name to array of JSON metadata objects
    */
-  querySetsMetadata?: Record<string, Record<string, any>>;
+  querySetsMetadata?: Record<string, IQuerySetMetadata>;
   /**
    * Number of replication runs.
    */

--- a/lib/SparqlBenchmarkRunner.ts
+++ b/lib/SparqlBenchmarkRunner.ts
@@ -22,7 +22,7 @@ export class SparqlBenchmarkRunner {
   protected readonly logger?: (message: string) => void;
   protected readonly resultAggregator: IResultAggregator;
   protected readonly availabilityCheckTimeout: number;
-  protected readonly resetCacheBetweenSetExecutions: boolean;
+  protected readonly sendResetSignalBetweenQuerySets: boolean;
   public readonly endpointFetcher: SparqlEndpointFetcher;
 
   public constructor(options: ISparqlBenchmarkRunnerArgs) {
@@ -38,7 +38,7 @@ export class SparqlBenchmarkRunner {
     this.requestDelay = options.requestDelay;
     this.bindingsHashAlgorithm = 'md5';
     this.availabilityCheckTimeout = options.availabilityCheckTimeout ?? 10_000;
-    this.resetCacheBetweenSetExecutions = options.resetCacheBetweenSetExecutions ?? true;
+    this.sendResetSignalBetweenQuerySets = options.resetCacheBetweenSetExecutions ?? true;
     this.endpointFetcher = new SparqlEndpointFetcher({
       additionalUrlParams: options.additionalUrlParams,
       timeout: options.timeout,
@@ -129,7 +129,7 @@ export class SparqlBenchmarkRunner {
         }
 
         // Trigger the worker restart after completing the query set execution
-        if (this.resetCacheBetweenSetExecutions) {
+        if (this.sendResetSignalBetweenQuerySets) {
           this.log(`Sending cache refresh signal to trigger worker restart.`);
           try {
             await fetch(this.endpoint, {

--- a/lib/SparqlBenchmarkRunner.ts
+++ b/lib/SparqlBenchmarkRunner.ts
@@ -3,7 +3,7 @@ import type * as RDF from '@rdfjs/types';
 import { SparqlEndpointFetcher } from 'fetch-sparql-endpoint';
 import { termToString } from 'rdf-string';
 import type { IQuerySetMetadata } from './QueryLoader';
-import type { IResult, IResultMetadata, IRunResult } from './Result';
+import type { IAggregateResult, IResult, IResultMetadata, IRunResult } from './Result';
 import type { IResultAggregator } from './ResultAggregator';
 import { ResultAggregatorComunica } from './ResultAggregatorComunica';
 
@@ -51,7 +51,15 @@ export class SparqlBenchmarkRunner {
    * execute all query sets against the SPARQL endpoint.
    * Afterwards, all results are collected and averaged.
    */
-  public async run(options: IRunOptions = {}): Promise<IRunResult> {
+  public async run(options: IRunOptions = {}): Promise<IAggregateResult[]> {
+    const result = await this.runWithRawResults(options);
+    return result.aggregateResults;
+  }
+
+  /**
+   * Runs the queries and return aggregated and raw results
+   */
+  public async runWithRawResults(options: IRunOptions = {}): Promise<IRunResult> {
     // Execute queries in warmup
     if (this.warmup > 0) {
       await this.executeAllQueries(this.warmup, true, options.onQuery);

--- a/lib/SparqlBenchmarkRunner.ts
+++ b/lib/SparqlBenchmarkRunner.ts
@@ -115,7 +115,7 @@ export class SparqlBenchmarkRunner {
           const context = contextStr ? JSON.parse(contextStr) : {};
 
           // 3. Modify the object
-          context.cleanCache = true;
+          context.clearCache = true;
 
           // 4. Stringify and set back
           newAdditionalParams.set('context', JSON.stringify(context));

--- a/lib/SparqlBenchmarkRunner.ts
+++ b/lib/SparqlBenchmarkRunner.ts
@@ -69,20 +69,11 @@ export class SparqlBenchmarkRunner {
     }
 
     const aggregateResults = this.resultAggregator.aggregateResults(results);
-    // Keep the aggregate results array identity so existing callers can keep using `run()` as before.
-    const runResult = aggregateResults;
-    Object.defineProperties(runResult, {
-      aggregateResults: {
-        value: aggregateResults,
-        enumerable: false,
-      },
-      rawResults: {
-        value: results,
-        enumerable: false,
-      },
-    });
-    // Backward compatibility: callers may still treat the return value as the aggregate results array.
-    return <IRunResult>runResult;
+
+    return {
+      aggregateResults,
+      rawResults: results,
+    };
   }
 
   /**

--- a/lib/SparqlBenchmarkRunner.ts
+++ b/lib/SparqlBenchmarkRunner.ts
@@ -69,7 +69,7 @@ export class SparqlBenchmarkRunner {
     }
 
     const aggregateResults = this.resultAggregator.aggregateResults(results);
-    const runResult = <IRunResult><unknown>aggregateResults;
+    const runResult = aggregateResults;
     Object.defineProperties(runResult, {
       aggregateResults: {
         value: aggregateResults,
@@ -80,7 +80,8 @@ export class SparqlBenchmarkRunner {
         enumerable: false,
       },
     });
-    return runResult;
+    // Backward compatibility: callers may still treat the return value as the aggregate results array.
+    return <IRunResult>runResult;
   }
 
   /**

--- a/lib/SparqlBenchmarkRunner.ts
+++ b/lib/SparqlBenchmarkRunner.ts
@@ -69,7 +69,7 @@ export class SparqlBenchmarkRunner {
     }
 
     const aggregateResults = this.resultAggregator.aggregateResults(results);
-    const runResult = <IRunResult>aggregateResults;
+    const runResult = <IRunResult><unknown>aggregateResults;
     Object.defineProperties(runResult, {
       aggregateResults: {
         value: aggregateResults,

--- a/lib/SparqlBenchmarkRunner.ts
+++ b/lib/SparqlBenchmarkRunner.ts
@@ -73,9 +73,11 @@ export class SparqlBenchmarkRunner {
     Object.defineProperties(runResult, {
       aggregateResults: {
         value: aggregateResults,
+        enumerable: false,
       },
       rawResults: {
         value: results,
+        enumerable: false,
       },
     });
     return runResult;

--- a/lib/SparqlBenchmarkRunner.ts
+++ b/lib/SparqlBenchmarkRunner.ts
@@ -23,7 +23,7 @@ export class SparqlBenchmarkRunner {
   protected readonly logger?: (message: string) => void;
   protected readonly resultAggregator: IResultAggregator;
   protected readonly availabilityCheckTimeout: number;
-  protected readonly sendResetSignalBetweenQuerySets: boolean;
+  protected readonly invalidateCacheBetweenSetExecutions: boolean;
   public readonly endpointFetcher: SparqlEndpointFetcher;
 
   public constructor(options: ISparqlBenchmarkRunnerArgs) {
@@ -39,7 +39,7 @@ export class SparqlBenchmarkRunner {
     this.requestDelay = options.requestDelay;
     this.bindingsHashAlgorithm = 'md5';
     this.availabilityCheckTimeout = options.availabilityCheckTimeout ?? 10_000;
-    this.sendResetSignalBetweenQuerySets = options.resetCacheBetweenSetExecutions ?? false;
+    this.invalidateCacheBetweenSetExecutions = options.invalidateCacheBetweenSetExecutions ?? false;
     this.endpointFetcher = new SparqlEndpointFetcher({
       additionalUrlParams: options.additionalUrlParams,
       timeout: options.timeout,
@@ -132,14 +132,14 @@ export class SparqlBenchmarkRunner {
         }
 
         // Trigger the worker restart after completing the query set execution
-        if (this.sendResetSignalBetweenQuerySets) {
-          this.log(`Sending cache refresh signal to trigger worker restart.`);
+        if (this.invalidateCacheBetweenSetExecutions) {
+          this.log(`Sending cache invalidation signal to trigger worker restart.`);
           try {
-            const refreshHeaders = new Headers();
-            refreshHeaders.set('x-comunica-refresh-cache', 'true');
+            const invalidationHeaders = new Headers();
+            invalidationHeaders.set('x-comunica-refresh-cache', 'true');
             await fetch(this.endpoint, {
               method: 'GET',
-              headers: refreshHeaders,
+              headers: invalidationHeaders,
             });
           } catch {
             // Suppress error: The server terminates the connection forcefully during shutdown.
@@ -351,7 +351,7 @@ export interface ISparqlBenchmarkRunnerArgs {
   /**
    * If the engine should reset the cache between executions
    */
-  resetCacheBetweenSetExecutions?: boolean;
+  invalidateCacheBetweenSetExecutions?: boolean;
   /**
    * The delay between subsequent requests sent to the server.
    */

--- a/lib/SparqlBenchmarkRunner.ts
+++ b/lib/SparqlBenchmarkRunner.ts
@@ -69,6 +69,7 @@ export class SparqlBenchmarkRunner {
     }
 
     const aggregateResults = this.resultAggregator.aggregateResults(results);
+    // Keep the aggregate results array identity so existing callers can keep using `run()` as before.
     const runResult = aggregateResults;
     Object.defineProperties(runResult, {
       aggregateResults: {

--- a/lib/SparqlBenchmarkRunner.ts
+++ b/lib/SparqlBenchmarkRunner.ts
@@ -69,11 +69,16 @@ export class SparqlBenchmarkRunner {
     }
 
     const aggregateResults = this.resultAggregator.aggregateResults(results);
-
-    return {
-      aggregateResults,
-      rawResults: results,
-    };
+    const runResult = <IRunResult>aggregateResults;
+    Object.defineProperties(runResult, {
+      aggregateResults: {
+        value: aggregateResults,
+      },
+      rawResults: {
+        value: results,
+      },
+    });
+    return runResult;
   }
 
   /**

--- a/lib/SparqlBenchmarkRunner.ts
+++ b/lib/SparqlBenchmarkRunner.ts
@@ -219,8 +219,7 @@ export class SparqlBenchmarkRunner {
     return result;
   }
 
-  public attachMetadataToResults(results: IResult[], metadatas?: IQuerySetMetadata):
-  Record<string, any>[] {
+  public attachMetadataToResults(results: IResult[], metadatas?: IQuerySetMetadata): IResult[] {
     return results.map((result, i) => {
       const metadata = metadatas?.[i];
       return metadata ? { ...result, ...metadata } : { ...result };

--- a/lib/SparqlBenchmarkRunner.ts
+++ b/lib/SparqlBenchmarkRunner.ts
@@ -103,39 +103,19 @@ export class SparqlBenchmarkRunner {
 
     for (const [ name, queryStrings ] of Object.entries(this.querySets)) {
       for (let i = 0; i < replication; i++) {
-        let resetDone = false;
-        const oldAdditionalParams = new URLSearchParams(this.endpointFetcher.additionalUrlParams);
-        if (this.resetCacheBetweenSetExecutions) {
-          const newAdditionalParams = new URLSearchParams(this.endpointFetcher.additionalUrlParams);
-
-          // 1. Get existing context JSON string
-          const contextStr = newAdditionalParams.get('context');
-
-          // 2. Parse to object (be careful: it may be null)
-          const context = contextStr ? JSON.parse(contextStr) : {};
-
-          // 3. Modify the object
-          context.clearCache = true;
-
-          // 4. Stringify and set back
-          newAdditionalParams.set('context', JSON.stringify(context));
-          this.endpointFetcher.additionalUrlParams = newAdditionalParams;
-          resetDone = true;
-        }
         for (const [ id, queryString ] of queryStrings.entries()) {
           this.log(`Execute: ${(++finishedExecutions).toString().padStart(totalExecutions.length, ' ')} / ${totalExecutions} <${name}#${id}>`);
+          
           await this.waitForEndpoint();
+          
           if (this.requestDelay) {
             await this.sleep(this.requestDelay);
           }
           if (onQuery) {
             await onQuery(queryString);
           }
+          
           let result = await this.executeQuery(name, id.toString(), queryString);
-
-          if (resetDone) {
-            this.endpointFetcher.additionalUrlParams = oldAdditionalParams;
-          }
 
           if (this.querySetsMetadata && Object.keys(this.querySetsMetadata).length > 0) {
             result = { ...result, ...<any[]> this.querySetsMetadata[name][id] };
@@ -145,6 +125,21 @@ export class SparqlBenchmarkRunner {
           }
           if (this.requestDelay) {
             await this.sleep(this.requestDelay);
+          }
+        }
+
+        // Trigger the worker restart after completing the query set execution
+        if (this.resetCacheBetweenSetExecutions) {
+          this.log(`Sending cache refresh signal to trigger worker restart.`);
+          try {
+            await fetch(this.endpoint, {
+              method: 'GET',
+              headers: {
+                'x-comunica-refresh-cache': 'true'
+              }
+            });
+          } catch {
+            // Suppress error: The server terminates the connection forcefully during shutdown.
           }
         }
       }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -5,4 +5,5 @@ export * from './ResultAggregator';
 export * from './ResultAggregatorComunica';
 export * from './ResultSerializer';
 export * from './ResultSerializerCsv';
+export * from './ResultSerializerRaw';
 export * from './SparqlBenchmarkRunner';

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -3,6 +3,7 @@ export * from './QueryLoaderFile';
 export * from './Result';
 export * from './ResultAggregator';
 export * from './ResultAggregatorComunica';
+export * from './ResultAggregatorComunicaQuerySequence';
 export * from './ResultSerializer';
 export * from './ResultSerializerCsv';
 export * from './ResultSerializerRaw';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rubeneschauzier/sparql-benchmark-runner",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "packageManager": "yarn@1.22.22",
   "description": "Executes a query set against a given SPARQL endpoint",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rubeneschauzier/sparql-benchmark-runner",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "packageManager": "yarn@1.22.22",
   "description": "Executes a query set against a given SPARQL endpoint",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rubeneschauzier/sparql-benchmark-runner",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "packageManager": "yarn@1.22.22",
   "description": "Executes a query set against a given SPARQL endpoint",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "sparql-benchmark-runner",
+  "name": "@rubeneschauzier/sparql-benchmark-runner",
   "version": "5.0.0",
   "packageManager": "yarn@1.22.22",
   "description": "Executes a query set against a given SPARQL endpoint",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rubeneschauzier/sparql-benchmark-runner",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "packageManager": "yarn@1.22.22",
   "description": "Executes a query set against a given SPARQL endpoint",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rubeneschauzier/sparql-benchmark-runner",
-  "version": "5.0.6",
+  "version": "5.0.8",
   "packageManager": "yarn@1.22.22",
   "description": "Executes a query set against a given SPARQL endpoint",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rubeneschauzier/sparql-benchmark-runner",
-  "version": "5.0.5",
+  "version": "5.0.6",
   "packageManager": "yarn@1.22.22",
   "description": "Executes a query set against a given SPARQL endpoint",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@rubeneschauzier/sparql-benchmark-runner",
-  "version": "5.0.8",
+  "name": "sparql-benchmark-runner",
+  "version": "5.0.1",
   "packageManager": "yarn@1.22.22",
   "description": "Executes a query set against a given SPARQL endpoint",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rubeneschauzier/sparql-benchmark-runner",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "packageManager": "yarn@1.22.22",
   "description": "Executes a query set against a given SPARQL endpoint",
   "license": "MIT",

--- a/test/QueryLoaderFile-test.ts
+++ b/test/QueryLoaderFile-test.ts
@@ -6,16 +6,8 @@ import { QueryLoaderFile } from '../lib/QueryLoaderFile';
 
 const queryFilesPath = '/tmp/queries';
 
-const queryFiles: Record<string, string> = {
-  'a.rq': 'A',
-  'b.sparql': 'B1\n\nB2\n\n\n\n',
-  'c.txt': 'C',
-  'd.json': 'D',
-  'dir/': 'true',
-};
-const queryFilesSub: Record<string, string> = {
-  'e.sparql': 'E',
-};
+let queryFiles: Record<string, string>;
+let queryFilesSub: Record<string, string>;
 
 jest.mock<typeof fsPromises>('node:fs/promises', () => <typeof fsPromises> <unknown> ({
   async readdir(path: string): Promise<Dirent[]> {
@@ -56,6 +48,16 @@ describe('QueryLoader', () => {
   let loader: IQueryLoader;
 
   beforeEach(() => {
+    queryFiles = {
+      'a.rq': 'A',
+      'b.sparql': 'B1\n\nB2\n\n\n\n',
+      'c.txt': 'C',
+      'd.json': 'D',
+      'dir/': 'true',
+    };
+    queryFilesSub = {
+      'e.sparql': 'E',
+    };
     loader = new QueryLoaderFile({ path: queryFilesPath });
   });
 
@@ -68,5 +70,55 @@ describe('QueryLoader', () => {
       'dir/e': [ 'E' ],
     };
     expect(queries).toEqual(queriesExpected);
+  });
+
+  it('should ignore non-metadata json files', async() => {
+    await expect(loader.loadQueriesMetadata()).resolves.toEqual({});
+  });
+
+  it('should load query metadata from metadata files', async() => {
+    queryFiles['a.metadata.json'] = JSON.stringify({
+      template: 'template-a',
+      provenance: 'dataset-a',
+      sequenceElements: [
+        { position: 0 },
+        { position: 1 },
+      ],
+    });
+    queryFilesSub['e.metadata.json'] = JSON.stringify({
+      template: 'template-e',
+      sequenceElements: [
+        { position: 2 },
+      ],
+    });
+
+    await expect(loader.loadQueriesMetadata()).resolves.toEqual({
+      a: [
+        {
+          template: 'template-a',
+          provenance: 'dataset-a',
+          sequenceElement: { position: 0 },
+        },
+        {
+          template: 'template-a',
+          provenance: 'dataset-a',
+          sequenceElement: { position: 1 },
+        },
+      ],
+      'dir/e': [
+        {
+          template: 'template-e',
+          sequenceElement: { position: 2 },
+        },
+      ],
+    });
+  });
+
+  it('should reject invalid metadata files', async() => {
+    queryFiles['a.metadata.json'] = JSON.stringify({
+      template: 'template-a',
+    });
+
+    await expect(loader.loadQueriesMetadata()).rejects.toThrow('queries metadata has no array entry');
   });
 });

--- a/test/ResultAggregatorComunicaQuerySequence-test.ts
+++ b/test/ResultAggregatorComunicaQuerySequence-test.ts
@@ -1,0 +1,120 @@
+import type { IAggregateResult, IResult } from '../lib/Result';
+import { ResultAggregatorComunicaQuerySequence } from '../lib/ResultAggregatorComunicaQuerySequence';
+
+describe('ResultAggregatorComunicaQuerySequence', () => {
+  it('handles results without sequence metadata', () => {
+    const aggregator = new ResultAggregatorComunicaQuerySequence();
+    const results: IResult[] = [
+      {
+        name: 'a',
+        id: '0',
+        results: 1,
+        hash: 'hash-a',
+        time: 10,
+        timestamps: [ 1 ],
+        httpRequests: 3,
+        sequenceElement: { template: 'template-a' },
+      },
+      {
+        name: 'b',
+        id: '0',
+        results: 2,
+        hash: 'hash-b',
+        time: 20,
+        timestamps: [ 2, 3 ],
+        httpRequests: 5,
+      },
+    ];
+
+    const aggregateResults: IAggregateResult[] = aggregator.aggregateResults(results);
+
+    expect(aggregateResults).toHaveLength(2);
+    expect(aggregateResults).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        name: 'template-a',
+        httpRequests: 3,
+      }),
+      expect.objectContaining({
+        name: 'b',
+        httpRequests: 5,
+      }),
+    ]));
+  });
+
+  it('groups aggregate results by name', () => {
+    const aggregator = new ResultAggregatorComunicaQuerySequence();
+
+    expect(aggregator.groupAggregateResults([
+      {
+        name: 'template-a',
+        id: '0',
+        results: 1,
+        hash: 'hash-a',
+        time: 10,
+        timestamps: [ 1 ],
+      },
+      {
+        name: 'template-a',
+        id: '1',
+        results: 1,
+        hash: 'hash-b',
+        time: 12,
+        timestamps: [ 2 ],
+      },
+    ])).toEqual({
+      'template-a': [
+        {
+          name: 'template-a',
+          id: '0',
+          results: 1,
+          hash: 'hash-a',
+          time: 10,
+          timestamps: [ 1 ],
+        },
+        {
+          name: 'template-a',
+          id: '1',
+          results: 1,
+          hash: 'hash-b',
+          time: 12,
+          timestamps: [ 2 ],
+        },
+      ],
+    });
+  });
+
+  it('aggregates http requests across repeated sequence results', () => {
+    const aggregator = new ResultAggregatorComunicaQuerySequence();
+
+    expect(aggregator.aggregateResults([
+      {
+        name: 'a',
+        id: '0',
+        results: 1,
+        hash: 'hash-a',
+        time: 10,
+        timestamps: [ 1 ],
+        httpRequests: 3,
+        sequenceElement: { template: 'template-a' },
+      },
+      {
+        name: 'a',
+        id: '0',
+        results: 1,
+        hash: 'hash-a',
+        time: 12,
+        timestamps: [ 2 ],
+        httpRequests: 5,
+        sequenceElement: { template: 'template-a' },
+      },
+    ])).toEqual([
+      expect.objectContaining({
+        name: 'template-a',
+        httpRequests: 4,
+        httpRequestsMax: 5,
+        httpRequestsMin: 3,
+        httpRequestsStd: 1,
+      }),
+    ]);
+  });
+});

--- a/test/ResultSerializerRaw-test.ts
+++ b/test/ResultSerializerRaw-test.ts
@@ -1,0 +1,80 @@
+import { writeFile } from 'node:fs/promises';
+import type { IResult } from '../lib/Result';
+import { ResultSerializerRaw } from '../lib/ResultSerializerRaw';
+
+jest.mock('node:fs/promises');
+const mockedWriteFile = jest.mocked(writeFile);
+
+describe('ResultSerializerRaw', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('constructor', () => {
+    it('assigns default separators when options are omitted', () => {
+      const serializer = new ResultSerializerRaw();
+
+      // Accessing protected properties via bracket notation for testing
+      expect((<any>serializer).columnSeparator).toBe(';');
+      expect((<any>serializer).arraySeparator).toBe(' ');
+    });
+
+    it('assigns provided separators from options', () => {
+      const serializer = new ResultSerializerRaw({
+        columnSeparator: ',',
+        arraySeparator: '|',
+      });
+
+      expect((<any>serializer).columnSeparator).toBe(',');
+      expect((<any>serializer).arraySeparator).toBe('|');
+    });
+  });
+
+  describe('serialize', () => {
+    it('serializes standard results to a JSON file', async() => {
+      const serializer = new ResultSerializerRaw();
+      const mockPath = 'output.json';
+
+      // Using type assertion to bypass full IResult interface implementation
+      const mockResults = <IResult[]><unknown> [
+        { name: 'benchmark1', ops: 100 },
+      ];
+
+      await serializer.serialize(mockPath, mockResults);
+
+      const expectedJson = JSON.stringify(
+        [{ name: 'benchmark1', ops: 100, error: undefined }],
+        null,
+        2,
+      );
+
+      expect(mockedWriteFile).toHaveBeenCalledTimes(1);
+      expect(mockedWriteFile).toHaveBeenCalledWith(mockPath, expectedJson, 'utf-8');
+    });
+
+    it('extracts error messages from Error objects', async() => {
+      const serializer = new ResultSerializerRaw();
+      const mockPath = 'error-output.json';
+
+      const errorObject = new Error('Memory limit exceeded');
+      const mockResults = <IResult[]><unknown> [
+        { name: 'benchmark1', error: errorObject },
+        { name: 'benchmark2', error: 'String error fallback' },
+      ];
+
+      await serializer.serialize(mockPath, mockResults);
+
+      const expectedJson = JSON.stringify(
+        [
+          { name: 'benchmark1', error: 'Memory limit exceeded' },
+          { name: 'benchmark2', error: 'String error fallback' },
+        ],
+        null,
+        2,
+      );
+
+      expect(mockedWriteFile).toHaveBeenCalledTimes(1);
+      expect(mockedWriteFile).toHaveBeenCalledWith(mockPath, expectedJson, 'utf-8');
+    });
+  });
+});

--- a/test/SparqlBenchmarkRunner-test.ts
+++ b/test/SparqlBenchmarkRunner-test.ts
@@ -183,8 +183,11 @@ describe('SparqlBenchmarkRunner', () => {
       expect(fetcher.fetchBindings).toHaveBeenCalledTimes(expectedCalls);
       expect(fetch).toHaveBeenCalledTimes(expectedCalls);
 
+      expect(results).toEqual(expectedResults);
       expect(results.aggregateResults).toEqual(expectedResults);
       expect(results.rawResults).toHaveLength(Object.values(querySets).flatMap(qs => qs).length * replication);
+      expect(Object.keys(results)).not.toContain('aggregateResults');
+      expect(Object.keys(results)).not.toContain('rawResults');
     });
 
     it('waits until endpoint is up', async() => {

--- a/test/SparqlBenchmarkRunner-test.ts
+++ b/test/SparqlBenchmarkRunner-test.ts
@@ -183,14 +183,8 @@ describe('SparqlBenchmarkRunner', () => {
       expect(fetcher.fetchBindings).toHaveBeenCalledTimes(expectedCalls);
       expect(fetch).toHaveBeenCalledTimes(expectedCalls);
 
-      expect(Array.isArray(results)).toBe(true);
-      expect(results).toHaveLength(expectedResults.length);
-      expect(results[0]).toEqual(expectedResults[0]);
-      expect([ ...results ]).toEqual(expectedResults);
       expect(results.aggregateResults).toEqual(expectedResults);
       expect(results.rawResults).toHaveLength(Object.values(querySets).flatMap(qs => qs).length * replication);
-      expect(Object.keys(results)).not.toContain('aggregateResults');
-      expect(Object.keys(results)).not.toContain('rawResults');
     });
 
     it('waits until endpoint is up', async() => {

--- a/test/SparqlBenchmarkRunner-test.ts
+++ b/test/SparqlBenchmarkRunner-test.ts
@@ -184,6 +184,8 @@ describe('SparqlBenchmarkRunner', () => {
       expect(fetch).toHaveBeenCalledTimes(expectedCalls);
 
       expect(Array.isArray(results)).toBe(true);
+      expect(results).toHaveLength(expectedResults.length);
+      expect(results[0]).toEqual(expectedResults[0]);
       expect([ ...results ]).toEqual(expectedResults);
       expect(results.aggregateResults).toEqual(expectedResults);
       expect(results.rawResults).toHaveLength(Object.values(querySets).flatMap(qs => qs).length * replication);

--- a/test/SparqlBenchmarkRunner-test.ts
+++ b/test/SparqlBenchmarkRunner-test.ts
@@ -183,7 +183,8 @@ describe('SparqlBenchmarkRunner', () => {
       expect(fetcher.fetchBindings).toHaveBeenCalledTimes(expectedCalls);
       expect(fetch).toHaveBeenCalledTimes(expectedCalls);
 
-      expect(results).toEqual(expectedResults);
+      expect(results.aggregateResults).toEqual(expectedResults);
+      expect(results.rawResults).toHaveLength(Object.values(querySets).flatMap(qs => qs).length * replication);
     });
 
     it('waits until endpoint is up', async() => {
@@ -314,6 +315,21 @@ describe('SparqlBenchmarkRunner', () => {
     });
 
     it('handles valid queries with metadata', async() => {
+      runner = new SparqlBenchmarkRunner({
+        endpoint,
+        querySets,
+        querySetsMetadata: {
+          a: [
+            {
+              template: 'template-a',
+              sequenceElement: { template: 'template-a', position: 0 },
+            },
+          ],
+        },
+        replication,
+        warmup,
+        logger,
+      });
       jest.spyOn(fetcher, 'fetchBindings').mockImplementation(async() => {
         const stream = streamifyArray([ ...mockedResult ]);
         stream.on('newListener', () => {
@@ -333,6 +349,8 @@ describe('SparqlBenchmarkRunner', () => {
           hash: mockedResultHash,
           timestamps: [ 3, 4, 5 ],
           httpRequests: 6,
+          template: 'template-a',
+          sequenceElement: { template: 'template-a', position: 0 },
         },
         {
           time: 13,
@@ -351,6 +369,8 @@ describe('SparqlBenchmarkRunner', () => {
           hash: mockedResultHash,
           timestamps: [ 17, 18, 19 ],
           httpRequests: 34,
+          template: 'template-a',
+          sequenceElement: { template: 'template-a', position: 0 },
         },
         {
           time: 27,
@@ -407,6 +427,65 @@ describe('SparqlBenchmarkRunner', () => {
       }
 
       expect(results).toEqual(expectedResults);
+    });
+
+    it('handles partial query metadata', async() => {
+      runner = new SparqlBenchmarkRunner({
+        endpoint,
+        querySets,
+        querySetsMetadata: {
+          a: [
+            {
+              template: 'template-a',
+              sequenceElement: { template: 'template-a', position: 0 },
+            },
+          ],
+        },
+        replication,
+        warmup,
+        logger,
+      });
+
+      const results = await runner.executeAllQueries(replication, false);
+
+      expect(results[0]).toMatchObject({
+        name: 'a',
+        id: '0',
+        template: 'template-a',
+        sequenceElement: { template: 'template-a', position: 0 },
+      });
+      expect(results[1]).toMatchObject({
+        name: 'a',
+        id: '1',
+      });
+      expect(results[1]).not.toHaveProperty('template');
+      expect(results[4]).toMatchObject({
+        name: 'b',
+        id: '0',
+      });
+      expect(results[4]).not.toHaveProperty('template');
+    });
+
+    it('sends cache refresh requests only when enabled', async() => {
+      runner = new SparqlBenchmarkRunner({
+        endpoint,
+        querySets,
+        replication,
+        warmup,
+        logger,
+        resetCacheBetweenSetExecutions: true,
+      });
+
+      await runner.executeAllQueries(replication, false);
+
+      const queryExecutions = replication * Object.values(querySets).flatMap(qs => qs).length;
+      const refreshExecutions = replication * Object.keys(querySets).length;
+      expect(fetch).toHaveBeenCalledTimes(queryExecutions + refreshExecutions);
+      const lastCall = jest.mocked(fetch).mock.calls.at(-1);
+      expect(lastCall?.[0]).toBe(endpoint);
+      expect(lastCall?.[1]).toMatchObject({ method: 'GET' });
+      expect(lastCall?.[1]?.headers).toBeInstanceOf(Headers);
+      expect((<Headers> lastCall?.[1]?.headers).get('x-comunica-refresh-cache')).toBe('true');
     });
 
     it('handles valid queries when a timeout is configured', async() => {
@@ -1112,6 +1191,55 @@ describe('SparqlBenchmarkRunner', () => {
       expect(logger).toHaveBeenNthCalledWith(1, 'Executing 2 query sets, containing 4 queries, with replication of 2');
       expect(logger).toHaveBeenNthCalledWith(2, 'Execute: 1 / 8 <a#0>');
       expect(logger).toHaveBeenNthCalledWith(3, `${expectedError.name}: ${expectedError.message}`);
+    });
+  });
+
+  describe('attachMetadataToResults', () => {
+    it('attaches metadata when present', () => {
+      expect(runner.attachMetadataToResults([
+        {
+          name: 'a',
+          id: '0',
+          results: 1,
+          hash: 'hash-a',
+          time: 10,
+          timestamps: [ 1 ],
+        },
+      ], [
+        { template: 'template-a' },
+      ])).toEqual([
+        {
+          name: 'a',
+          id: '0',
+          results: 1,
+          hash: 'hash-a',
+          time: 10,
+          timestamps: [ 1 ],
+          template: 'template-a',
+        },
+      ]);
+    });
+
+    it('returns shallow copies when metadata is absent', () => {
+      expect(runner.attachMetadataToResults([
+        {
+          name: 'a',
+          id: '0',
+          results: 1,
+          hash: 'hash-a',
+          time: 10,
+          timestamps: [ 1 ],
+        },
+      ])).toEqual([
+        {
+          name: 'a',
+          id: '0',
+          results: 1,
+          hash: 'hash-a',
+          time: 10,
+          timestamps: [ 1 ],
+        },
+      ]);
     });
   });
 

--- a/test/SparqlBenchmarkRunner-test.ts
+++ b/test/SparqlBenchmarkRunner-test.ts
@@ -183,6 +183,7 @@ describe('SparqlBenchmarkRunner', () => {
       expect(fetcher.fetchBindings).toHaveBeenCalledTimes(expectedCalls);
       expect(fetch).toHaveBeenCalledTimes(expectedCalls);
 
+      expect(Array.isArray(results)).toBe(true);
       expect([ ...results ]).toEqual(expectedResults);
       expect(results.aggregateResults).toEqual(expectedResults);
       expect(results.rawResults).toHaveLength(Object.values(querySets).flatMap(qs => qs).length * replication);

--- a/test/SparqlBenchmarkRunner-test.ts
+++ b/test/SparqlBenchmarkRunner-test.ts
@@ -82,6 +82,7 @@ describe('SparqlBenchmarkRunner', () => {
       });
 
       const results = await runner.run();
+      const resultsRaw = await runner.runWithRawResults();
 
       const expectedResults: IAggregateResult[] = [
         {
@@ -178,15 +179,23 @@ describe('SparqlBenchmarkRunner', () => {
         },
       ];
 
-      // Calls: (warmup + replication) * queryset size
-      const expectedCalls = Object.values(querySets).flatMap(qs => qs).length * (replication + warmup);
+      // Calls: (warmup + replication) * queryset size * 2 (accounting for both test executions)
+      const expectedCalls = Object.values(querySets).flatMap(qs => qs).length * (replication + warmup) * 2;
       expect(fetcher.fetchBindings).toHaveBeenCalledTimes(expectedCalls);
       expect(fetch).toHaveBeenCalledTimes(expectedCalls);
 
-      expect(Array.isArray(results)).toBe(false);
-      expect((<{ 0?: IAggregateResult }><unknown>results)[0]).toBeUndefined();
-      expect(results.aggregateResults).toEqual(expectedResults);
-      expect(results.rawResults).toHaveLength(Object.values(querySets).flatMap(qs => qs).length * replication);
+      // Validate run()
+      expect(Array.isArray(results)).toBe(true);
+      expect((<{ rawResults?: any }><unknown>results).rawResults).toBeUndefined();
+      expect(results).toEqual(expectedResults);
+
+      // Validate runWithRawResults() structure and lengths
+      expect(resultsRaw).toHaveProperty('aggregateResults');
+      expect(resultsRaw).toHaveProperty('rawResults');
+      expect(Array.isArray(resultsRaw.aggregateResults)).toBe(true);
+      expect(Array.isArray(resultsRaw.rawResults)).toBe(true);
+      expect(resultsRaw.aggregateResults).toHaveLength(expectedResults.length);
+      expect(resultsRaw.rawResults).toHaveLength(Object.values(querySets).flatMap(qs => qs).length * replication);
     });
 
     it('waits until endpoint is up', async() => {

--- a/test/SparqlBenchmarkRunner-test.ts
+++ b/test/SparqlBenchmarkRunner-test.ts
@@ -183,7 +183,7 @@ describe('SparqlBenchmarkRunner', () => {
       expect(fetcher.fetchBindings).toHaveBeenCalledTimes(expectedCalls);
       expect(fetch).toHaveBeenCalledTimes(expectedCalls);
 
-      expect(results).toEqual(expectedResults);
+      expect([ ...results ]).toEqual(expectedResults);
       expect(results.aggregateResults).toEqual(expectedResults);
       expect(results.rawResults).toHaveLength(Object.values(querySets).flatMap(qs => qs).length * replication);
       expect(Object.keys(results)).not.toContain('aggregateResults');

--- a/test/SparqlBenchmarkRunner-test.ts
+++ b/test/SparqlBenchmarkRunner-test.ts
@@ -468,21 +468,21 @@ describe('SparqlBenchmarkRunner', () => {
       expect(results[4]).not.toHaveProperty('template');
     });
 
-    it('sends cache refresh requests only when enabled', async() => {
+    it('sends cache invalidation requests only when enabled', async() => {
       runner = new SparqlBenchmarkRunner({
         endpoint,
         querySets,
         replication,
         warmup,
         logger,
-        resetCacheBetweenSetExecutions: true,
+        invalidateCacheBetweenSetExecutions: true,
       });
 
       await runner.executeAllQueries(replication, false);
 
       const queryExecutions = replication * Object.values(querySets).flatMap(qs => qs).length;
-      const refreshExecutions = replication * Object.keys(querySets).length;
-      expect(fetch).toHaveBeenCalledTimes(queryExecutions + refreshExecutions);
+      const invalidateExecutions = replication * Object.keys(querySets).length;
+      expect(fetch).toHaveBeenCalledTimes(queryExecutions + invalidateExecutions);
       const lastCall = jest.mocked(fetch).mock.calls.at(-1);
       expect(lastCall?.[0]).toBe(endpoint);
       expect(lastCall?.[1]).toMatchObject({ method: 'GET' });

--- a/test/SparqlBenchmarkRunner-test.ts
+++ b/test/SparqlBenchmarkRunner-test.ts
@@ -183,6 +183,8 @@ describe('SparqlBenchmarkRunner', () => {
       expect(fetcher.fetchBindings).toHaveBeenCalledTimes(expectedCalls);
       expect(fetch).toHaveBeenCalledTimes(expectedCalls);
 
+      expect(Array.isArray(results)).toBe(false);
+      expect((<{ 0?: IAggregateResult }><unknown>results)[0]).toBeUndefined();
       expect(results.aggregateResults).toEqual(expectedResults);
       expect(results.rawResults).toHaveLength(Object.values(querySets).flatMap(qs => qs).length * replication);
     });


### PR DESCRIPTION
This PR adds the code required to run sequence-based benchmarks, specifically for use with SolidSessionBench. It introduces the following features:

* **Query metadata:** Enables attaching metadata to queries in a query set to indicate the template and other sequence-dependent details.
* **Raw result serialization:** Serializes raw execution results because the default aggregation scheme is unsuitable for sequences. This option is also available in the default SolidBench to enable custom aggregation and data processing.
* **Cache refresh requests:** Sends a request to Comunica using a custom header to clear the cache between sequences. Note that this refresh argument is not yet standardized and may not work across all Comunica versions.

Note that this is a breaking change, as the output of the runner is changed to also output the raw results.